### PR TITLE
Build symbols for gtp-vport linux 4.9 module required for openvswitch…

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -77,6 +77,11 @@ override_dh_install-indep:
 	# check we can get kernel module names
 	$(MAKE) -C datapath print-build-modules
 
+
+	# make GTP flow based kernel patch
+	cd flow-based-gtp-linux-v4.9 && $(MAKE) build
+	cp flow-based-gtp-linux-v4.9/Module.symvers debian/$(PACKAGE_DKMS)/usr/src/$(PACKAGE)-$(DEB_VERSION_UPSTREAM)/datapath/linux
+
 	# Prepare dkms.conf from the dkms.conf.in template
 	sed "s/__VERSION__/$(DEB_VERSION_UPSTREAM)/g; s/__MODULES__/$(shell $(MAKE) -C datapath print-build-modules | grep -v make)/" debian/dkms.conf.in > debian/$(PACKAGE_DKMS)/usr/src/$(PACKAGE)-$(DEB_VERSION_UPSTREAM)/dkms.conf
 

--- a/debian/rules.modules
+++ b/debian/rules.modules
@@ -23,6 +23,9 @@ binary-modules: prep-deb-files
 	dh_testroot
 	dh_clean -k
 	tar xzf openvswitch.tar.gz
+	cd flow-based-gtp-linux-v4.9 && $(MAKE) package
+	mv flow-based-gtp-linux-v4.9/*.deb $(DEB_DESTDIR)
+	cp flow-based-gtp-linux-v4.9/Module.symvers openvswitch/datapath/linux
 	cd openvswitch && ./configure --with-linux=$(KSRC) $(DATAPATH_CONFIGURE_OPTS)
 	cd openvswitch && $(MAKE) -C datapath/linux
 	install -d -m755 $(DSTDIR)


### PR DESCRIPTION
Loads flow based gtp module in OVS makefile. Requires cloning flow-based-gtp-linux-v4.9 into repo before compilation. Should review licensing.
This is workaround until the gtp-vport module lands to netnext repos